### PR TITLE
fix: Resolve undefined globEager in Vite 5 and above

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,5 +5,5 @@ import { registerControllers } from 'stimulus-vite-helpers'
 const application = Application.start()
 
 // Controller files must be named *_controller.js.
-const controllers  = import.meta.globEager('./**/*_controller.js')
+const controllers  = import.meta.glob('./**/*_controller.js', {eager: true})
 registerControllers(application, controllers)


### PR DESCRIPTION
Addressed the issue where globEager function became undefined  in Vite 5 and later versions. This fix ensures the project  functions correctly with Vite 5+.

ref: https://github.com/vitejs/vite/discussions/7066#discussioncomment-9142979 , https://evilmartians.com/chronicles/vite-lizing-rails-get-live-reload-and-hot-replacement-with-vite-ruby